### PR TITLE
Token parameter and result

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -42,11 +42,11 @@ class Provider extends AbstractProvider implements ProviderInterface
         $response = $this->getHttpClient()->get('https://'.$this->getConfig('subdomain').'.myshopify.com/admin/shop.json', [
             'headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => 'Bearer '.$token,
+                'X-Shopify-Access-Token' => $token,
             ],
         ]);
 
-        return json_decode($response->getBody(), true);
+        return json_decode($response->getBody(), true)['shop'];
     }
 
     /**


### PR DESCRIPTION
Shopify expects 'X-Shopify-Access-Token' in the header
Shopify returns result inside shop object.